### PR TITLE
Validate PID after getting it from pidfile

### DIFF
--- a/SOURCES/anicorn
+++ b/SOURCES/anicorn
@@ -376,7 +376,7 @@ getPID() {
     return
   fi
 
-  echo $pid
+  echo "$pid"
 }
 
 # Extract path to PID file from Unicorn config

--- a/SOURCES/anicorn
+++ b/SOURCES/anicorn
@@ -357,17 +357,26 @@ monitorStoppedUnicorn() {
   kill -TERM "$pid"
 }
 
-# Read PID from PID file
+# Read PID from PID file and validate it
 #
 # Code: No
 # Echo: PID (Number)
 getPID() {
+  local pid
+
   if [[ ! -e "$pid_file" ]] ; then
     echo ""
     return
   fi
 
-  tr -d '\n\r' < "$pid_file"
+  pid=$(tr -d '\n\r' < "$pid_file")
+
+  if [[ ! -e "/proc/$pid" ]] ; then
+    echo ""
+    return
+  fi
+
+  echo $pid
 }
 
 # Extract path to PID file from Unicorn config


### PR DESCRIPTION
### What did you implement:

Closes #10 

### How did you implement it:

Added a check for PID existence (via /proc fs) after reading it from pidfile.

Now, the absence of pidfile and stale pidfile are both discarded and no pid is returned from the function.

### How can we verify it:

I tested this function in isolation with the following script:

```bash
echo 'NO FILE'
getPID

echo 'FILE WITH STALE PID'
pid_file=NOPID # actual file with nonexistent pid 999
getPID

echo 'FILE WITH ACTIVE PID'
pid_file=YESPID # actual file with existing pid from ps
getPID
```

Here are the results:

```
NO FILE

FILE WITH STALE PID

FILE WITH ACTIVE PID
13333
```

So, it only returns existing pids now.

### TODO's:

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**Is this ready for review?:** Yes
**Is it a breaking change?:** No
