### PR TITLE
Remove stale PID if process is dead to prevent failure during on Unicorn restarting

### DIFF
--- a/SOURCES/anicorn
+++ b/SOURCES/anicorn
@@ -3,7 +3,7 @@
 ########################################################################################
 
 APP="Anicorn"
-VER="2.1.4"
+VER="2.1.5"
 DESC="Simple utility for starting/restarting Unicorn"
 
 ########################################################################################
@@ -147,7 +147,7 @@ checkRuby() {
   fi
 }
 
-# Check path to PID file
+# Check path to PID file and clean PID file if it exists and process is dead
 #
 # Code: No
 # Echo: No
@@ -155,6 +155,14 @@ checkPIDFile() {
   if [[ -z "$pid_file" ]] ; then
     log "[ERROR] Can't extract path to PID file from Unicorn config"
     exit 1
+  fi
+
+  local pid
+
+  pid=$(getPID)
+
+  if [[ "$pid" == "" && -e "$pid_file" ]] ; then
+      rm -f $pid_file
   fi
 }
 

--- a/SOURCES/anicorn
+++ b/SOURCES/anicorn
@@ -162,7 +162,7 @@ checkPIDFile() {
   pid=$(getPID)
 
   if [[ "$pid" == "" && -e "$pid_file" ]] ; then
-      rm -f $pid_file
+      rm -f "$pid_file"
   fi
 }
 

--- a/SOURCES/anicorn
+++ b/SOURCES/anicorn
@@ -147,6 +147,24 @@ checkRuby() {
   fi
 }
 
+# Check if running process is Unicorn
+#
+# 1: Process ID (Integer)
+#
+# Code: No
+# Echo: No
+isUnicornProcess() {
+    local pid
+
+    pid="$1"
+
+    if [[ -e "/proc/$pid" ]] ; then
+        return $(grep -qaE ^unicorn < "/proc/$pid/cmdline")
+    else
+        return 1
+    fi
+}
+
 # Check path to PID file and clean PID file if it exists and process is dead
 #
 # Code: No
@@ -163,6 +181,11 @@ checkPIDFile() {
 
   if [[ "$pid" == "" && -e "$pid_file" ]] ; then
       rm -f "$pid_file"
+  fi
+
+  if ! isUnicornProcess "$pid" ; then
+    log "[ERROR] Running process with PID ${pid} is not a Unicorn"
+    exit 1
   fi
 }
 

--- a/SOURCES/anicorn
+++ b/SOURCES/anicorn
@@ -151,7 +151,7 @@ checkRuby() {
 #
 # 1: Process ID (Integer)
 #
-# Code: No
+# Code: Yes
 # Echo: No
 isUnicornProcess() {
     local pid

--- a/SOURCES/anicorn
+++ b/SOURCES/anicorn
@@ -159,7 +159,8 @@ isUnicornProcess() {
     pid="$1"
 
     if [[ -e "/proc/$pid" ]] ; then
-        return $(grep -qaE ^unicorn < "/proc/$pid/cmdline")
+        grep -qaE ^unicorn < "/proc/$pid/cmdline"
+        return $?
     else
         return 1
     fi

--- a/anicorn.spec
+++ b/anicorn.spec
@@ -2,7 +2,7 @@
 
 Summary:         Simple utility for starting/restarting Unicorn
 Name:            anicorn
-Version:         2.1.4
+Version:         2.1.5
 Release:         0%{?dist}
 Group:           Applications/System
 License:         EKOL
@@ -43,6 +43,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Jul 04 2018 Gleb Goncharov <g.goncharov@fun-box.ru> - 2.1.5-0
+- Fixed bug with trying to restart Unicorn when it is dead and PID file exists
+
 * Fri Jun 22 2018 Anton Novojilov <andy@essentialkaos.com> - 2.1.4-0
 - Fixed bug with handling command line arguments
 


### PR DESCRIPTION
### What did you implement:

In case Unicorn process has been stopped with SIGKILL signal and PID file is exists, `anicorn` tries to restart Unicorn and, unsurprisingly, exits with an error. I suggest adding an extra check of PID file existence and remove it if process is dead.

### How did you implement it:

I added one more condition to `checkPIDFile` function to remove stale PID file.

### How can we verify it:

1. Finish Unicorn process with SIGKILL signal.
2. Make sure that PID file exists.
3. Run `anicorn`.

It should successfully start the new Unicorn process.

**Is this ready for review?:** Yes
**Is it a breaking change?:** No