### PR TITLE
Fix getting PID from empty PID file

### DIFF
--- a/SOURCES/anicorn
+++ b/SOURCES/anicorn
@@ -180,15 +180,13 @@ checkPIDFile() {
 
   pid=$(getPID)
 
-  if [[ "$pid" == "" && -e "$pid_file" ]] ; then
+  if [[ -n "$pid" ]] ; then
+      if ! isUnicornProcess "$pid" ; then
+          log "[ERROR] Running process with PID ${pid} is not a Unicorn"
+          exit 1
+      fi
+  else
       rm -f "$pid_file"
-  fi
-
-  if [[ "$pid" != "" ]] ; then
-    if ! isUnicornProcess "$pid" ; then
-      log "[ERROR] Running process with PID ${pid} is not a Unicorn"
-      exit 1
-    fi
   fi
 }
 

--- a/SOURCES/anicorn
+++ b/SOURCES/anicorn
@@ -410,7 +410,7 @@ getPID() {
 
   pid=$(tr -d '\n\r' < "$pid_file")
 
-  if [[ ! -e "/proc/$pid" ]] ; then
+  if [[ ! -e "/proc/$pid" || ! -n "$pid" ]] ; then
     echo ""
     return
   fi


### PR DESCRIPTION
### What did you implement:

I found that `getPID()` and `checkPID()` functions does not work as expected. `checkPID()` does not remove PID file if PID file exists but it is empty. So I have tried to fix it.

### How did you implement it:

1) Added extra check to `getPID()` function. It is not necessary, but it makes source code more readable and clear.
2) Fixed if-condition: force remove PID file with empty PID even if it does not exists. Otherwise we should check if running process is a Unicorn process.

### How can we verify it:

1) Run Anicorn with Unicorn
2) Truncate PID file.
3) Restart Anicorn.

After these steps we should be able to run Anicorn with deleted PID file.

**Is this ready for review?:** Yes
**Is it a breaking change?:** No
